### PR TITLE
Todo登録画面のレイアウトを作成 #11

### DIFF
--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/MainActivity.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/MainActivity.kt
@@ -3,17 +3,12 @@ package com.example.todo_app_mvvm_with_clean_architectrue
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.material3.ExperimentalMaterial3Api
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.theme.TODOAPPMVVMwithCleanArchitectrueTheme
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list.TodoListScreen
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_register/TodoRegisterScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_register/TodoRegisterScreen.kt
@@ -1,0 +1,106 @@
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_register
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodoRegisterScreen() {
+    val text = remember {
+        mutableStateOf("")
+    }
+    Scaffold(
+        topBar = { TodoRegisterAppBar() },
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(it)
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "タイトル",
+                fontSize = 16.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+            )
+            TextField(
+                value = text.value,
+                onValueChange = { text.value = it },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "詳細",
+                fontSize = 16.sp,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            TextField(
+                value = text.value,
+                onValueChange = { text.value = it },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(480.dp),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodoRegisterAppBar() {
+    TopAppBar(
+        title = { Text("Todo登録", color = Color.White) },
+        navigationIcon = {
+            IconButton(
+                onClick = {}
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = "Back Arrow",
+                    tint = Color.White
+                )
+            }
+        },
+        colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Blue)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TodoRegisterScreenPreview() {
+    TodoRegisterScreen()
+}


### PR DESCRIPTION
#11

<img width="217" alt="impl-todo-register-screen-layout" src="https://github.com/yoshi1075/TODO-APP-MVVM-with-Clean-Architectrue/assets/82593696/a6157d06-9837-4666-93f3-3a68e4b40a6c">
