### PR TITLE
Todo編集画面を実装 #18

### DIFF
--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/MainActivity.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/MainActivity.kt
@@ -4,10 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.theme.TODOAPPMVVMwithCleanArchitectrueTheme
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit.TodoEditScreen
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list.TodoListScreen
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_register.TodoRegisterScreen
 
@@ -24,12 +27,22 @@ class MainActivity : ComponentActivity() {
                 ) {
                     composable("list") {
                         TodoListScreen(
-                            navigateToTodoRegisterScreen = { navController.navigate("register") }
+                            navigateToTodoRegisterScreen = { navController.navigate("register") },
+                            navigateToTodoEditScreen = { todoId -> navController.navigate("edit/$todoId") }
                         )
                     }
                     composable("register") {
                         TodoRegisterScreen(
-                            backTodoListScreen = { navController.popBackStack() }
+                            backToTodoListScreen = { navController.popBackStack() }
+                        )
+                    }
+                    composable(
+                        "edit/{todoId}",
+                        arguments = listOf(navArgument("todoId") { type = NavType.IntType })
+                    ) {
+                        TodoEditScreen(
+                            backToTodoListScreen = { navController.popBackStack() },
+                            todoId = it.arguments?.getInt("todoId") ?: 0
                         )
                     }
                 }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/data/Todo.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/data/Todo.kt
@@ -5,5 +5,6 @@ import java.util.UUID
 data class Todo(
     val id: UUID = UUID.randomUUID(),
     val title: String,
+    val detail: String = "",
     val isDone: Boolean = false,
 )

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
@@ -1,4 +1,4 @@
-package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_register
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -29,61 +29,63 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.todo_app_mvvm_with_clean_architectrue.data.Todo
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodoRegisterScreen(backToTodoListScreen: () -> Unit) {
-    val titleText = remember { mutableStateOf("") }
-    val detailText = remember { mutableStateOf("") }
-    Scaffold(
-        topBar = { TodoRegisterAppBar(backToTodoListScreen) },
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(it)
-                .padding(horizontal = 16.dp),
+fun TodoEditScreen(todoId: Int, backToTodoListScreen: () -> Unit) {
+    val todo = Todo(title = "title$todoId")
+    val titleText = remember { mutableStateOf(todo.title) }
+    val detailText = remember { mutableStateOf(todo.detail) }
+        Scaffold(
+            topBar = { TodoRegisterAppBar(backToTodoListScreen) },
         ) {
-            Text(
-                text = "タイトル",
-                fontSize = 16.sp,
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp)
-            )
-            TextField(
-                value = titleText.value,
-                onValueChange = { titleText.value = it },
-                textStyle = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp),
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-            Text(
-                text = "詳細",
-                fontSize = 16.sp,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            TextField(
-                value = detailText.value,
-                onValueChange = { detailText.value = it },
-                textStyle = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(480.dp),
-            )
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(it)
+                    .padding(horizontal = 16.dp),
+            ) {
+                Text(
+                    text = "タイトル",
+                    fontSize = 16.sp,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp)
+                )
+                TextField(
+                    value = titleText.value,
+                    onValueChange = { titleText.value = it },
+                    textStyle = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = "詳細",
+                    fontSize = 16.sp,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                TextField(
+                    value = detailText.value,
+                    onValueChange = { detailText.value = it },
+                    textStyle = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(480.dp),
+                )
+            }
         }
-    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TodoRegisterAppBar(backToTodoListScreen: () -> Unit) {
     TopAppBar(
-        title = { Text("Todo登録", color = Color.White) },
+        title = { Text("Todo編集", color = Color.White) },
         navigationIcon = {
             IconButton(
                 onClick = { backToTodoListScreen() }
@@ -113,5 +115,5 @@ fun TodoRegisterAppBar(backToTodoListScreen: () -> Unit) {
 @Preview(showBackground = true)
 @Composable
 fun TodoRegisterScreenPreview() {
-    TodoRegisterScreen {}
+    TodoEditScreen(1, {})
 }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
@@ -38,7 +38,7 @@ fun TodoEditScreen(todoId: Int, backToTodoListScreen: () -> Unit) {
     val titleText = remember { mutableStateOf(todo.title) }
     val detailText = remember { mutableStateOf(todo.detail) }
         Scaffold(
-            topBar = { TodoRegisterAppBar(backToTodoListScreen) },
+            topBar = { TodoEditAppBar(backToTodoListScreen) },
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -83,7 +83,7 @@ fun TodoEditScreen(todoId: Int, backToTodoListScreen: () -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodoRegisterAppBar(backToTodoListScreen: () -> Unit) {
+fun TodoEditAppBar(backToTodoListScreen: () -> Unit) {
     TopAppBar(
         title = { Text("Todo編集", color = Color.White) },
         navigationIcon = {
@@ -114,6 +114,6 @@ fun TodoRegisterAppBar(backToTodoListScreen: () -> Unit) {
 
 @Preview(showBackground = true)
 @Composable
-fun TodoRegisterScreenPreview() {
+fun TodoEditScreenPreview() {
     TodoEditScreen(1, {})
 }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListScreen.kt
@@ -1,6 +1,8 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -32,6 +34,7 @@ import com.example.todo_app_mvvm_with_clean_architectrue.ui.theme.TODOAPPMVVMwit
 @Composable
 fun TodoListScreen(
     navigateToTodoRegisterScreen: () -> Unit,
+    navigateToTodoEditScreen: (Int) -> Unit,
 ) {
     Scaffold(
         topBar = { TodoListAppBar() },
@@ -46,6 +49,9 @@ fun TodoListScreen(
                 }
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .clickable { navigateToTodoEditScreen(index) }
+                        .fillMaxWidth()
                 ) {
                     Checkbox(
                         checked = todo.value.isDone,
@@ -88,6 +94,6 @@ fun AddingTodoFloatingButton(navigateToTodoRegisterScreen: () -> Unit) {
 @Composable
 fun TodoListScreenPreview() {
     TODOAPPMVVMwithCleanArchitectrueTheme {
-        TodoListScreen {}
+        TodoListScreen({}, {})
     }
 }


### PR DESCRIPTION
# やったこと
* 画面遷移処理を追加
  * 遷移時にtodoのindexを渡す
* 関数名をリファクタリング
* Todoクラスにdetailを追加
* Todo登録画面にも、戻る処理を追加

https://github.com/yoshi1075/TODO-APP-MVVM-with-Clean-Architectrue/assets/82593696/eb1da162-2477-4dc1-9597-d07d9190cd9c

#18