### PR TITLE
Todo編集画面に、Todo削除ダイアログのUIを実装 #25

### DIFF
--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -21,8 +24,10 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,9 +42,36 @@ fun TodoEditScreen(todoId: Int, backToTodoListScreen: () -> Unit) {
     val todo = Todo(title = "title$todoId")
     val titleText = remember { mutableStateOf(todo.title) }
     val detailText = remember { mutableStateOf(todo.detail) }
+    var showsDialog by remember { mutableStateOf(false) }
+
         Scaffold(
-            topBar = { TodoEditAppBar(backToTodoListScreen) },
+            topBar = { TodoEditAppBar({ showsDialog = true }, backToTodoListScreen) },
         ) {
+            if (showsDialog) {
+                AlertDialog(
+                    onDismissRequest = { showsDialog = false },
+                    confirmButton = {
+                        Button(
+                            onClick = {
+                                // TODO: 削除処理
+                                showsDialog = false
+                            }
+                        ) {
+                            Text("削除")
+                        }
+                    },
+                    dismissButton = {
+                        Button(
+                            onClick = { showsDialog = false }
+                        ) {
+                            Text("キャンセル")
+                        }
+                    },
+                    title = { Text(text = "Todoを削除しますか？") },
+                    text = { Text(text = "この動作は取り消せません") },
+                )
+            }
+
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
@@ -83,7 +115,7 @@ fun TodoEditScreen(todoId: Int, backToTodoListScreen: () -> Unit) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodoEditAppBar(backToTodoListScreen: () -> Unit) {
+fun TodoEditAppBar(showDialog: () -> Unit, backToTodoListScreen: () -> Unit) {
     TopAppBar(
         title = { Text("Todo編集", color = Color.White) },
         navigationIcon = {
@@ -93,19 +125,28 @@ fun TodoEditAppBar(backToTodoListScreen: () -> Unit) {
                 Icon(
                     imageVector = Icons.Filled.ArrowBack,
                     contentDescription = "Back Arrow",
-                    tint = Color.White
+                    tint = Color.White,
                 )
             }
         },
         colors = TopAppBarDefaults.smallTopAppBarColors(containerColor = Color.Blue),
         actions = {
             IconButton(
+                onClick = { showDialog() }
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Delete,
+                    contentDescription = "Delete",
+                    tint = Color.White,
+                )
+            }
+            IconButton(
                 onClick = { backToTodoListScreen() }
             ) {
                 Icon(
                     imageVector = Icons.Filled.Check,
                     contentDescription = "Check",
-                    tint = Color.White
+                    tint = Color.White,
                 )
             }
         }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
@@ -44,73 +44,73 @@ fun TodoEditScreen(todoId: Int, backToTodoListScreen: () -> Unit) {
     val detailText = remember { mutableStateOf(todo.detail) }
     var showsDialog by remember { mutableStateOf(false) }
 
-        Scaffold(
-            topBar = { TodoEditAppBar({ showsDialog = true }, backToTodoListScreen) },
-        ) {
-            if (showsDialog) {
-                AlertDialog(
-                    onDismissRequest = { showsDialog = false },
-                    confirmButton = {
-                        Button(
-                            onClick = {
-                                // TODO: 削除処理
-                                showsDialog = false
-                            }
-                        ) {
-                            Text("削除")
+    Scaffold(
+        topBar = { TodoEditAppBar({ showsDialog = true }, backToTodoListScreen) },
+    ) {
+        if (showsDialog) {
+            AlertDialog(
+                onDismissRequest = { showsDialog = false },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            // TODO: 削除処理
+                            showsDialog = false
                         }
-                    },
-                    dismissButton = {
-                        Button(
-                            onClick = { showsDialog = false }
-                        ) {
-                            Text("キャンセル")
-                        }
-                    },
-                    title = { Text(text = "Todoを削除しますか？") },
-                    text = { Text(text = "この動作は取り消せません") },
-                )
-            }
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(it)
-                    .padding(horizontal = 16.dp),
-            ) {
-                Text(
-                    text = "タイトル",
-                    fontSize = 16.sp,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp)
-                )
-                TextField(
-                    value = titleText.value,
-                    onValueChange = { titleText.value = it },
-                    textStyle = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp),
-                )
-                Spacer(modifier = Modifier.height(24.dp))
-                Text(
-                    text = "詳細",
-                    fontSize = 16.sp,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                TextField(
-                    value = detailText.value,
-                    onValueChange = { detailText.value = it },
-                    textStyle = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(480.dp),
-                )
-            }
+                    ) {
+                        Text("削除")
+                    }
+                },
+                dismissButton = {
+                    Button(
+                        onClick = { showsDialog = false }
+                    ) {
+                        Text("キャンセル")
+                    }
+                },
+                title = { Text(text = "Todoを削除しますか？") },
+                text = { Text(text = "この動作は取り消せません") },
+            )
         }
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(it)
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "タイトル",
+                fontSize = 16.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+            )
+            TextField(
+                value = titleText.value,
+                onValueChange = { titleText.value = it },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "詳細",
+                fontSize = 16.sp,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            TextField(
+                value = detailText.value,
+                onValueChange = { detailText.value = it },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(480.dp),
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
* Todo削除ダイアログの表示処理を追加
* インデントの修正

#25

https://github.com/yoshi1075/TODO-APP-MVVM-with-Clean-Architectrue/assets/82593696/f36d9f2e-81e8-4d7a-811b-5d10cae7f99f

