### PR TITLE
savedStateHandleからnavigation-argsを受け取る #56

### DIFF
--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/navigation/AppNavHost.kt
@@ -55,7 +55,6 @@ fun AppNavHost(navController: NavHostController) {
                 state,
                 viewModel::onEvent,
                 backToTodoListScreen = { navController.popBackStack() },
-                todoId = it.arguments?.getInt("todoId") ?: 0
             )
         }
     }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditEvent.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditEvent.kt
@@ -1,7 +1,7 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit
 
 sealed interface TodoEditEvent {
-    data class OnLaunched(val todoId: Int) : TodoEditEvent
+    object OnLaunched: TodoEditEvent
     data class OnTitleUpdated(val title: String) : TodoEditEvent
     data class OnDetailUpdated(val detail: String) : TodoEditEvent
     object OnDeleteIconTapped : TodoEditEvent

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditScreen.kt
@@ -32,13 +32,12 @@ import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit.components
 fun TodoEditScreen(
     state: TodoEditUiState,
     onEvent: (TodoEditEvent) -> Unit,
-    todoId: Int,
     backToTodoListScreen: () -> Unit,
 ) {
     val hostState = SnackbarHostState()
 
     LaunchedEffect(Unit) {
-        onEvent(TodoEditEvent.OnLaunched(todoId))
+        onEvent(TodoEditEvent.OnLaunched)
     }
 
     LaunchedEffect(state.oneTimeEvent) {

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditViewModel.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.todo_app_mvvm_with_clean_architectrue.data.TodoRepository
@@ -12,7 +13,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TodoEditViewModel @Inject constructor(
-    private val todoRepository: TodoRepository
+    private val savedStateHandle: SavedStateHandle,
+    private val todoRepository: TodoRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TodoEditUiState())
     val uiState = _uiState.asStateFlow()
@@ -21,7 +23,8 @@ class TodoEditViewModel @Inject constructor(
         when (event) {
             is TodoEditEvent.OnLaunched -> {
                 viewModelScope.launch {
-                    todoRepository.getTodo(event.todoId).let { todo ->
+                    val todoId = checkNotNull(savedStateHandle.get<Int>("todoId"))
+                    todoRepository.getTodo(todoId).let { todo ->
                         _uiState.update {
                             uiState.value.copy(todo = todo, title = todo.title, detail = todo.detail)
                         }


### PR DESCRIPTION
* savedStateHandleからNavigationのArgsを受け取る
  * [受け取り方](https://medium.com/@KaushalVasava/navigation-in-jetpack-compose-full-guide-beginner-to-advanced-950c1133740#:~:text=private%20val%20userId%3A%20String%20%3D%20checkNotNull(savedStateHandle%5B%22userId%22%5D))
  * [savedStateHandleをViewModelの引数に受け取る仕組み](https://zenn.dev/morayl/scraps/89c58723eb37da)
* [checkNotNull vs requireNotNull](https://zenn.dev/red_fat_daruma/articles/0acb0898dedc5834a056)