### PR TITLE
Todo登録画面にPreview機能を追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,14 +63,14 @@ dependencies {
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
-    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.7.0-alpha03")
     implementation("androidx.compose.material3:material3")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.7.0-alpha03")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
     // navigation

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListScreen.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list
 
 import androidx.compose.foundation.layout.Box
@@ -14,12 +16,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.theme.TODOAPPMVVMwithCleanArchitectrueTheme
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list.components.AddingTodoFloatingButton
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list.components.TodoListAppBar
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list.components.TodoListItem
 
-@ExperimentalMaterial3Api
 @Composable
 fun TodoListScreen(
     state: TodoListUiState,
@@ -60,5 +64,21 @@ fun TodoListScreen(
                 )
             }
         }
+    }
+}
+
+@PreviewScreenSizes
+@Preview(
+    showSystemUi = true,
+)
+@Composable
+fun TodoListScreenPreview() {
+    TODOAPPMVVMwithCleanArchitectrueTheme {
+        TodoListScreen(
+            state = TodoListUiState(),
+            onEvent = {},
+            navigateToTodoRegisterScreen = {},
+            navigateToTodoEditScreen = {},
+        )
     }
 }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/components/AddingTodoFloatingButton.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/components/AddingTodoFloatingButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun AddingTodoFloatingButton(navigateToTodoRegisterScreen: () -> Unit) {
@@ -12,4 +13,14 @@ fun AddingTodoFloatingButton(navigateToTodoRegisterScreen: () -> Unit) {
         onClick = { navigateToTodoRegisterScreen() }) {
         Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
     }
+}
+
+@Preview(
+    widthDp = 100,
+    heightDp = 100,
+    showBackground = true,
+)
+@Composable
+fun AddingTodoFloatingButtonPreview() {
+    AddingTodoFloatingButton {}
 }


### PR DESCRIPTION
[コンポーザブルのプレビューで UI をプレビューする](https://developer.android.com/jetpack/compose/tooling/previews?hl=ja)

<img width="478" alt="スクリーンショット 2024-02-29 14 35 14" src="https://github.com/yoshi1075/TODO-APP-MVVM-with-Clean-Architectrue/assets/82593696/3e5795ea-7b8d-4af5-9c86-f7e0eaeef7e8">
<img width="479" alt="スクリーンショット 2024-02-29 14 35 23" src="https://github.com/yoshi1075/TODO-APP-MVVM-with-Clean-Architectrue/assets/82593696/576f4536-6f38-4d20-a646-804eb9ff9ff4">
