### PR TITLE
ViewModelにsavedStateHandleを実装し、Activityが破棄されても画面データを復旧できるように修正

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
+    id("kotlin-parcelize")
 }
 
 kotlin {
@@ -58,7 +59,6 @@ android {
 dependencies {
 
     implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.activity:activity-compose:1.8.2")
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
     implementation("androidx.compose.ui:ui")
@@ -72,6 +72,11 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling:1.7.0-alpha03")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    // lifecycle
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0") // savable
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0") // collectAsStateWithLifecycle
 
     // navigation
     implementation("androidx.navigation:navigation-compose:2.7.7")

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/data/Todo.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/data/Todo.kt
@@ -1,10 +1,13 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.data
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import kotlin.random.Random
 
+@Parcelize
 data class Todo(
     val id: Int = Random.nextInt(),
     val title: String,
     val detail: String = "",
     val isDone: Boolean = false,
-)
+) : Parcelable

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/extensions/SavedStateHandle+.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/extensions/SavedStateHandle+.kt
@@ -1,0 +1,24 @@
+@file:OptIn(SavedStateHandleSaveableApi::class)
+
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.extensions
+
+import androidx.compose.runtime.saveable.Saver
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
+import androidx.lifecycle.viewmodel.compose.saveable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.properties.PropertyDelegateProvider
+import kotlin.properties.ReadOnlyProperty
+
+fun <T : Any> SavedStateHandle.saveableMutableStateFlow(init: () -> MutableStateFlow<T>): PropertyDelegateProvider<Any?, ReadOnlyProperty<Any?, MutableStateFlow<T>>> {
+    return saveable(
+        saver = Saver(
+            save = {
+                it.value
+            },
+            restore = {
+                MutableStateFlow(it)
+            }),
+        init = init
+    )
+}

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/navigation/AppNavHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -37,7 +38,7 @@ fun AppNavHost(navController: NavHostController) {
         }
         composable(NavigationItem.Register.route) {
             val viewModel: TodoRegisterViewModel = hiltViewModel()
-            val state by viewModel.uiState.collectAsState()
+            val state by viewModel.uiState.collectAsStateWithLifecycle()
             TodoRegisterScreen(
                 state,
                 viewModel.oneTimeEvent,

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditOneTimeEvent.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditOneTimeEvent.kt
@@ -1,7 +1,13 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit
 
-sealed interface TodoEditOneTimeEvent {
-    object Nothing : TodoEditOneTimeEvent
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+sealed interface TodoEditOneTimeEvent : Parcelable {
+    @Parcelize
+    data object Nothing : TodoEditOneTimeEvent
+    @Parcelize
     data class ShowSnackbar(val message: String) : TodoEditOneTimeEvent
-    object NavigateToListScreen : TodoEditOneTimeEvent
+    @Parcelize
+    data object NavigateToListScreen : TodoEditOneTimeEvent
 }

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditUiState.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_edit/TodoEditUiState.kt
@@ -1,11 +1,14 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit
 
+import android.os.Parcelable
 import com.example.todo_app_mvvm_with_clean_architectrue.data.Todo
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class TodoEditUiState(
     val todo: Todo = Todo(title = "", detail = ""),
     val title: String = "",
     val detail: String = "",
     val showsDialog: Boolean = false,
     val oneTimeEvent: TodoEditOneTimeEvent = TodoEditOneTimeEvent.Nothing
-)
+) : Parcelable

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListUiState.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListUiState.kt
@@ -1,8 +1,11 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list
 
+import android.os.Parcelable
 import com.example.todo_app_mvvm_with_clean_architectrue.data.Todo
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class TodoListUiState(
     val showsLoadingDialog: Boolean = false,
     val todos: List<Todo> = emptyList(),
-)
+) : Parcelable

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListViewModel.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_list/TodoListViewModel.kt
@@ -1,8 +1,10 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.todo_app_mvvm_with_clean_architectrue.data.TodoRepository
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.extensions.saveableMutableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,9 +16,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TodoListViewModel @Inject constructor(
-    private val todoRepository: TodoRepository
+    savedStateHandle: SavedStateHandle,
+    private val todoRepository: TodoRepository,
 ) : ViewModel() {
-    private val _uiState: MutableStateFlow<TodoListUiState> = MutableStateFlow(TodoListUiState())
+    private val _uiState by savedStateHandle.saveableMutableStateFlow {
+        MutableStateFlow(TodoListUiState())
+    }
     val uiState = _uiState.asStateFlow()
 
     fun onEvent(event: TodoListEvent) {

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_register/TodoRegisterUiState.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_register/TodoRegisterUiState.kt
@@ -1,6 +1,10 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_register
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class TodoRegisterUiState(
     val title: String = "",
     val detail: String = "",
-)
+) : Parcelable

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_register/TodoRegisterViewModel.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/todo_register/TodoRegisterViewModel.kt
@@ -1,9 +1,11 @@
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_register
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.todo_app_mvvm_with_clean_architectrue.data.Todo
 import com.example.todo_app_mvvm_with_clean_architectrue.data.TodoRepository
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.extensions.saveableMutableStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,9 +17,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TodoRegisterViewModel @Inject constructor(
-    private val todoRepository: TodoRepository
+    private val todoRepository: TodoRepository,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(TodoRegisterUiState())
+    private val _uiState by savedStateHandle.saveableMutableStateFlow {
+        MutableStateFlow(TodoRegisterUiState())
+    }
     val uiState = _uiState.asStateFlow()
 
     private val _oneTimeEvent = Channel<TodoRegisterOneTimeEvent>()


### PR DESCRIPTION
* savedStateHandle
  * [savedStateHandleに画面データを保持する理由＋collectAsStateWithLifecycle](https://note.com/kauche/n/n27d456bcaa78)
  * [savableをStateFlowに対応させる](https://qiita.com/yuichi0515/items/d667a9589d4823890ea0)
* @Parcelable
  * [Parcelable 実装生成ツール](https://developer.android.com/kotlin/parcelize?hl=ja)
  * [seald classに@Parcelableを実装する](https://qiita.com/takahirom/items/5f3d405c854b6015823a)


https://github.com/yoshi1075/TODO-APP-MVVM-with-Clean-Architectrue/assets/82593696/a42ddd80-db78-4918-a974-d2afa5f0aa3f

