### PR TITLE
SharedViewModelを定義

### DIFF
--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/extensions/NavBackStackEntry+.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/extensions/NavBackStackEntry+.kt
@@ -1,0 +1,26 @@
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.extensions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavHostController
+
+/** 特定のnav_graph単位で存続するようなViewModelを生成する */
+@Composable
+inline fun <reified T : ViewModel> NavBackStackEntry.sharedViewModel(navController: NavHostController): T {
+
+    // 現在のnav_graphのparent.route
+    val navGraphRoute = destination.parent?.route ?: return hiltViewModel()
+
+    // 現在のnav_graphに紐づくNavBackStackEntryを取得する
+    val parentEntry = remember(this) {
+
+        // NavBackStackEntryが変化する度に実行
+        navController.getBackStackEntry(navGraphRoute)
+    }
+
+    // NavBackStackEntryをViewModelStoreOwnerとするViewModelを生成
+    return hiltViewModel(parentEntry)
+}

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/navigation/AppNavHost.kt
@@ -1,10 +1,6 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package com.example.todo_app_mvvm_with_clean_architectrue.ui.navigation
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -13,6 +9,8 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.extensions.sharedViewModel
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.shared.SharedViewModel
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit.TodoEditScreen
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_edit.TodoEditViewModel
 import com.example.todo_app_mvvm_with_clean_architectrue.ui.todo_list.TodoListScreen
@@ -26,9 +24,14 @@ fun AppNavHost(navController: NavHostController) {
         navController = navController,
         startDestination = NavigationItem.List.route,
     ) {
-        composable(NavigationItem.List.route) {
+        composable(NavigationItem.List.route) { backStackEntry ->
+
+            // FixMe: sharedViewModelを使用し、アプリ全体の表示/動作を制御する
+            val sharedViewModel = backStackEntry.sharedViewModel<SharedViewModel>(navController = navController)
+            val sharedState by sharedViewModel.sharedState.collectAsStateWithLifecycle()
+
             val viewModel: TodoListViewModel = hiltViewModel()
-            val state by viewModel.uiState.collectAsState()
+            val state by viewModel.uiState.collectAsStateWithLifecycle()
             TodoListScreen(
                 state,
                 viewModel::onEvent,
@@ -36,7 +39,12 @@ fun AppNavHost(navController: NavHostController) {
                 navigateToTodoEditScreen = { todoId -> navController.navigate(NavigationItem.Edit.route + "/$todoId") }
             )
         }
-        composable(NavigationItem.Register.route) {
+        composable(NavigationItem.Register.route) { backStackEntry ->
+
+            // FixMe: sharedViewModelを使用し、アプリ全体の表示/動作を制御する
+            val sharedViewModel = backStackEntry.sharedViewModel<SharedViewModel>(navController = navController)
+            val sharedState by sharedViewModel.sharedState.collectAsStateWithLifecycle()
+
             val viewModel: TodoRegisterViewModel = hiltViewModel()
             val state by viewModel.uiState.collectAsStateWithLifecycle()
             TodoRegisterScreen(
@@ -49,9 +57,14 @@ fun AppNavHost(navController: NavHostController) {
         composable(
             NavigationItem.Edit.route + "/{todoId}",
             arguments = listOf(navArgument("todoId") { type = NavType.IntType }),
-        ) {
+        ) { backStackEntry ->
+
+            // FixMe: sharedViewModelを使用し、アプリ全体の表示/動作を制御する
+            val sharedViewModel = backStackEntry.sharedViewModel<SharedViewModel>(navController = navController)
+            val sharedState by sharedViewModel.sharedState.collectAsStateWithLifecycle()
+
             val viewModel: TodoEditViewModel = hiltViewModel()
-            val state by viewModel.uiState.collectAsState()
+            val state by viewModel.uiState.collectAsStateWithLifecycle()
             TodoEditScreen(
                 state,
                 viewModel::onEvent,

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/shared/SharedEvent.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/shared/SharedEvent.kt
@@ -1,0 +1,7 @@
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.shared
+
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.navigation.NavigationItem
+
+sealed interface SharedEvent {
+    data class OnScreenLaunched(val navigationItem: NavigationItem) : SharedEvent
+}

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/shared/SharedState.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/shared/SharedState.kt
@@ -1,0 +1,9 @@
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.shared
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SharedState(
+    val title: String = "",
+) : Parcelable

--- a/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/shared/SharedViewModel.kt
+++ b/app/src/main/java/com/example/todo_app_mvvm_with_clean_architectrue/ui/shared/SharedViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.todo_app_mvvm_with_clean_architectrue.ui.shared
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.example.todo_app_mvvm_with_clean_architectrue.ui.extensions.saveableMutableStateFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class SharedViewModel @Inject constructor(savedStateHandle: SavedStateHandle) : ViewModel() {
+    private val _sharedState by savedStateHandle.saveableMutableStateFlow {
+        MutableStateFlow(SharedState())
+    }
+    val sharedState = _sharedState.asStateFlow()
+
+    fun onEvent(event: SharedEvent) {
+        // TODO: impl
+        when (event) {
+            is SharedEvent.OnScreenLaunched -> {
+                _sharedState.update { sharedState.value.copy(title = event.navigationItem.route)  }
+            }
+        }
+    }
+}


### PR DESCRIPTION
nav_graph単位でデータを保持するようなViewModelを作成
* 参考
  * SharedViewModelの導入
    * [記事](https://medium.com/@KaushalVasava/navigation-in-jetpack-compose-full-guide-beginner-to-advanced-950c1133740)
    * [動画](https://www.youtube.com/watch?v=h61Wqy3qcKg&t=5s)
  * ジェネリクス関数
    * [インライン関数とは（インライン展開について）](https://qiita.com/kaleidot725/items/1239fdf6268a64802f04)
    * [ジェネリクス関数と、`inline fun`＋`reified`の関係](https://maku77.github.io/kotlin/generics/reified.html)
  